### PR TITLE
Place Horizontal Navigation Limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,14 +31,24 @@
   <body>
     <div class="wrapper">
       <nav class="navigation">
-        <a class="nav__ctrl--slide-left navigation__component"
-         href="#nav">
+        <input type="radio" name="state-group--slide-limiter"
+         class="slide-limiter__state--lift"
+         id="slide-limiter--left__state--lift" />
+        <input type="radio" name="state-group--slide-limiter"
+         class="slide-limiter__state--lift"
+         id="slide-limiter--right__state--lift" />
+
+        <label for="slide-limiter--left__state--lift"
+         class="nav__ctrl--slide-left navigation__component" >
           <span class="fas fa-chevron-left"></span>
-        </a>
-        <a class="nav__ctrl--slide-right navigation__component"
-         href="#nav">
+        </label>
+        <label for="slide-limiter--right__state--lift"
+         class="nav__ctrl--slide-right navigation__component" >
           <span class="fas fa-chevron-right"></span>
-        </a>
+        </label>
+
+        <span class="slide-limiter--left"></span>
+        <span class="slide-limiter--right"></span>
 
         <input id="nav__state--visibility" type="checkbox"
          class="nav__state--visibility" />

--- a/navigation.css
+++ b/navigation.css
@@ -93,6 +93,8 @@
   }
 
 
+  .slide-limiter--left,
+  .slide-limiter--right,
   .nav__ctrl--slide-left,
   .nav__ctrl--slide-right {
     height: 100%;
@@ -102,6 +104,46 @@
     align-items: flex-end;
     position: absolute;
     text-decoration: none;
+    animation-duration: 400s;
+    animation-timing-function: linear;
+    animation-play-state: paused;
+    animation-fill-mode: forwards;
+    animation-iteration-count: infinite;
+  }
+
+
+  .slide-limiter--left,
+  .slide-limiter--right {
+    animation-name: lift-limiter;
+  }
+
+
+  .nav__ctrl--slide-left,
+  .nav__ctrl--slide-right {
+    animation-name: lift-ctrl;
+  }
+
+
+  .nav__ctrl--slide-right,
+  .slide-limiter--right {
+    right: 0;
+  }
+
+
+  #slide-limiter--right__state--lift:active ~ 
+      .nav__ctrl--slide-left,
+  #slide-limiter--right__state--lift:active ~
+      .slide-limiter--right,
+  #slide-limiter--left__state--lift:active ~ 
+      .nav__ctrl--slide-right,
+  #slide-limiter--left__state--lift:active ~
+      .slide-limiter--left {
+    animation-play-state: running;
+  }
+
+
+  .nav__ctrl--slide-left,
+  .nav__ctrl--slide-right {
     font-size: 200%;
     color: var(--primary-font-color);
 
@@ -117,7 +159,6 @@
 
 
   .nav__ctrl--slide-right {
-    right: 0;
     background: linear-gradient(270deg,
                                 hsla(0, 0%, 0%, 1),
                                 hsla(0, 0%, 0%, 0));
@@ -161,8 +202,8 @@
     flex: 0 0 20rem;
     opacity: 0.8;
     animation-name: slide-left;
-	transition-property: height;
-	transition-duration: 0.3s;
+    transition-property: height;
+    transition-duration: 0.3s;
   }
 
 
@@ -194,4 +235,15 @@
 @keyframes slide-right {
   from {left: 0rem;}
   to {left: -500rem;}
+}
+
+
+@keyframes lift-limiter {
+  from {z-index: 0; }
+  to {z-index: 9979; }
+}
+
+@keyframes lift-ctrl {
+  from {z-index: 20; }
+  to {z-index: 9999; }
 }


### PR DESCRIPTION
Create limiter elements that occupy the same x and y position as their
corresponding button. Clicking on each button will increase the z-index
for its corresponding limiter. Eventually after a number of clicks the
limiter will have a higher z-index than its corresponding button and
that button will no longer be "clickable". Clicking on a button will
also increase the z-index on the opposite button, exposing the button
and making that button interactive again.

- Create two absolutely positioned elements that will act as the
  limiter for the right and left navigation slide buttons. These
  limiters should be the same size or larger than their corresponding
  slide button.

- Place each limiter behind its corresponding button.

- Create an animation that will increase the z-index of the limiters,
  and another to increase the z-index of the buttons. Add these
  animation to their corresponding elements, and set the duration for
  all animations to the same value. The final z-index will be set to
  an arbitrarily high value (as high as you can take it). This will
  avoid, in most cases, the animation resetting, which could cause some
  unwanted behaviour. Pause the animations.

- Create two hidden input fields, making sure they are siblings to the
  limiters and buttons, and placed before both the limters and the
  buttons. Each button should be a label for one of these fields.

- Create a rule that will run the "lift button" animation for the opposite
  button of the one that is clicked on, and the lift limiter animation
  for the corresponding limiter of the button that is clicked.